### PR TITLE
build: Use bundler-cache in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,6 +1,10 @@
 name: test
 
-on: [push, pull_request]
+on:
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -16,7 +16,6 @@ jobs:
       uses: ruby/setup-ruby@v1
       with:
         ruby-version: ${{ matrix.ruby }}
-    - name: Install dependencies
-      run: bundle install
+        bundler-cache: true # 'bundle install' and cache results
     - name: Run test
-      run: rake test
+      run: bundle exec rake


### PR DESCRIPTION
This PR:

- uses the `bundler-cache` feature of the Ruby-maintained Action setup-ruby. [See ruby/setup-ruby](https://github.com/ruby/setup-ruby/blob/master/action.yml) for more information.
- Avoids duplicate CI Jobs for Pull Requests by only running tests on the `push` event for "master" branch.