### PR TITLE
ruby test-all suite, the leakchecker reported this Pipe leak in DRbUNIXSocket#close

### DIFF
--- a/lib/drb/unix.rb
+++ b/lib/drb/unix.rb
@@ -96,7 +96,10 @@ module DRb
       return unless @socket
       shutdown # DRbProtocol#shutdown
       path = @socket.path if @server_mode
-      @socket.close
+      begin
+        @socket.close
+      rescue Errno::EPIPE
+      end
       File.unlink(path) if @server_mode
       @socket = nil
       close_shutdown_pipe


### PR DESCRIPTION
when EPIPE error is raised, close_shutdown_pipe doesn't get called resulting in Pipe leak.