### PR TITLE
Support :SSL{Min,Max}Version config options

### DIFF
--- a/lib/drb/ssl.rb
+++ b/lib/drb/ssl.rb
@@ -73,6 +73,14 @@ module DRb
       # :SSLTmpDhCallback ::
       #   A DH callback. See OpenSSL::SSL::SSLContext.tmp_dh_callback
       #
+      # :SSLMinVersion ::
+      #   This is the minimum SSL version to allow.  See
+      #   OpenSSL::SSL::SSLContext#min_version=.
+      #
+      # :SSLMaxVersion ::
+      #   This is the maximum SSL version to allow.  See
+      #   OpenSSL::SSL::SSLContext#min_version=.
+      #
       # :SSLVerifyMode ::
       #   This is the SSL verification mode.  See OpenSSL::SSL::VERIFY_* for
       #   available modes.  The default is OpenSSL::SSL::VERIFY_NONE
@@ -208,6 +216,8 @@ module DRb
         ctx = ::OpenSSL::SSL::SSLContext.new
         ctx.cert            = @cert
         ctx.key             = @pkey
+        ctx.min_version     = self[:SSLMinVersion]
+        ctx.max_version     = self[:SSLMaxVersion]
         ctx.client_ca       = self[:SSLClientCA]
         ctx.ca_path         = self[:SSLCACertificatePath]
         ctx.ca_file         = self[:SSLCACertificateFile]

--- a/test/drb/test_drbssl.rb
+++ b/test/drb/test_drbssl.rb
@@ -23,6 +23,10 @@ class DRbSSLService < DRbService
     config[:SSLVerifyCallback] = lambda{ |ok,x509_store|
       true
     }
+    if RUBY_PLATFORM.match?(/openbsd/)
+      config[:SSLMinVersion] = OpenSSL::SSL::TLS1_2_VERSION
+      config[:SSLMaxVersion] = OpenSSL::SSL::TLS1_2_VERSION
+    end
     begin
       data = open("sample.key"){|io| io.read }
       config[:SSLPrivateKey] = OpenSSL::PKey::RSA.new(data)

--- a/test/drb/ut_array_drbssl.rb
+++ b/test/drb/ut_array_drbssl.rb
@@ -24,6 +24,10 @@ AQjjxMXhwULlmuR/K+WwlaZPiLIBYalLAZQ7ZbOPeVkJ8ePao0eLAgEC
 
   config = Hash.new
   config[:SSLTmpDhCallback] = proc { DRbTests::TEST_KEY_DH1024 }
+  if RUBY_PLATFORM.match?(/openbsd/)
+    config[:SSLMinVersion] = OpenSSL::SSL::TLS1_2_VERSION
+    config[:SSLMaxVersion] = OpenSSL::SSL::TLS1_2_VERSION
+  end
   config[:SSLVerifyMode] = OpenSSL::SSL::VERIFY_PEER
   config[:SSLVerifyCallback] = lambda{|ok,x509_store|
     true


### PR DESCRIPTION
These are necessary to get the tests passing with LibreSSL 3.8.1+, which dropped support for TLSv1.0 and TLSv1.1 for security reasons.

This updates the tests to use TLSv1.2 on OpenBSD.  This is only strictly necessary on OpenBSD 7.4+, but it will work fine in previous versions as well.