### PR TITLE
Use a single quote instead of a backtick as an open quote

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -1174,7 +1174,7 @@ module DRb
       prefix = "(#{uri}) "
       bt = []
       result.backtrace.each do |x|
-        break if /`__send__'$/ =~ x
+        break if /[`']__send__'$/ =~ x
         if /\A\(druby:\/\// =~ x
           bt.push(x)
         else
@@ -1594,26 +1594,26 @@ module DRb
     def check_insecure_method(obj, msg_id)
       return true if Proc === obj && msg_id == :__drb_yield
       raise(ArgumentError, "#{any_to_s(msg_id)} is not a symbol") unless Symbol == msg_id.class
-      raise(SecurityError, "insecure method `#{msg_id}'") if insecure_method?(msg_id)
+      raise(SecurityError, "insecure method '#{msg_id}'") if insecure_method?(msg_id)
 
       case obj
       when Object
         if obj.private_methods.include?(msg_id)
           desc = any_to_s(obj)
-          raise NoMethodError, "private method `#{msg_id}' called for #{desc}"
+          raise NoMethodError, "private method '#{msg_id}' called for #{desc}"
         elsif obj.protected_methods.include?(msg_id)
           desc = any_to_s(obj)
-          raise NoMethodError, "protected method `#{msg_id}' called for #{desc}"
+          raise NoMethodError, "protected method '#{msg_id}' called for #{desc}"
         else
           true
         end
       else
         if Kernel.instance_method(:private_methods).bind(obj).call.include?(msg_id)
           desc = any_to_s(obj)
-          raise NoMethodError, "private method `#{msg_id}' called for #{desc}"
+          raise NoMethodError, "private method '#{msg_id}' called for #{desc}"
         elsif Kernel.instance_method(:protected_methods).bind(obj).call.include?(msg_id)
           desc = any_to_s(obj)
-          raise NoMethodError, "protected method `#{msg_id}' called for #{desc}"
+          raise NoMethodError, "protected method '#{msg_id}' called for #{desc}"
         else
           true
         end

--- a/lib/drb/unix.rb
+++ b/lib/drb/unix.rb
@@ -81,7 +81,7 @@ module DRb
             break
           end
         rescue
-          raise "cannot generate tempfile `%s'" % tmpname if n >= Max_try
+          raise "cannot generate tempfile '%s'" % tmpname if n >= Max_try
           #sleep(1)
         end
         n += 1

--- a/test/drb/drbtest.rb
+++ b/test/drb/drbtest.rb
@@ -234,26 +234,26 @@ module DRbCore
     e = assert_raise(NoMethodError) {
       @there.method_missing(:eval, 'nil')
     }
-    assert_match(/^private method \`eval\'/, e.message)
+    assert_match(/^private method [`']eval\'/, e.message)
 
     e = assert_raise(NoMethodError) {
       @there.call_private_method
     }
-    assert_match(/^private method \`call_private_method\'/, e.message)
+    assert_match(/^private method [`']call_private_method\'/, e.message)
   end
 
   def test_07_protected_missing
     e = assert_raise(NoMethodError) {
       @there.call_protected_method
     }
-    assert_match(/^protected method \`call_protected_method\'/, e.message)
+    assert_match(/^protected method [`']call_protected_method\'/, e.message)
   end
 
   def test_07_public_missing
     e = assert_raise(NoMethodError) {
       @there.method_missing(:undefined_method_test)
     }
-    assert_match(/^undefined method \`undefined_method_test\'/, e.message)
+    assert_match(/^undefined method [`']undefined_method_test\'/, e.message)
   end
 
   def test_07_send_missing


### PR DESCRIPTION
https://bugs.ruby-lang.org/issues/16495