### PR TITLE
Fix warnings during test runs

### DIFF
--- a/test/drb/drbtest.rb
+++ b/test/drb/drbtest.rb
@@ -90,7 +90,7 @@ module DRbBase
   end
 
   def teardown
-    return if @omitted
+    return if instance_variable_defined?(:@omitted) && @omitted
     @ext.stop_service if defined?(@ext) && @ext
     if defined?(@service_name) && @service_name
       @drb_service.manager.unregist(@service_name)


### PR DESCRIPTION
```
[user@PC06 ruby-drb]$ bundle exec rake
Loaded suite /home/user/.rbenv/versions/2.7.8/lib/ruby/gems/2.7.0/gems/rake-13.1.0/lib/rake/rake_test_loader
Started
\/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
|/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
-/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
\/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
|/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
//home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
-/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
\/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
|/home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
//home/user/code/ruby-drb/test/drb/drbtest.rb:93: warning: instance variable @omitted not initialized
...
```