### PR TITLE
Drop dependency on ruby2_keywords

### DIFF
--- a/drb.gemspec
+++ b/drb.gemspec
@@ -38,6 +38,4 @@ Gem::Specification.new do |spec|
     lib/drb/weakidconv.rb
   ]
   spec.require_paths = ["lib"]
-
-  spec.add_dependency "ruby2_keywords"
 end

--- a/test/lib/helper.rb
+++ b/test/lib/helper.rb
@@ -1,6 +1,4 @@
 require "test/unit"
 require "core_assertions"
 
-require "ruby2_keywords"
-
 Test::Unit::TestCase.include Test::Unit::CoreAssertions


### PR DESCRIPTION
Added in #1

#4 bumped the minimum required ruby version to 2.7, so this is not needed anymore