### PR TITLE
Fix wrong certificate version

### DIFF
--- a/lib/drb/ssl.rb
+++ b/lib/drb/ssl.rb
@@ -185,7 +185,7 @@ module DRb
         }
 
         cert = OpenSSL::X509::Certificate.new
-        cert.version = 3
+        cert.version = 2
         cert.serial = 0
         name = OpenSSL::X509::Name.new(self[:SSLCertName])
         cert.subject = name


### PR DESCRIPTION
OpenSSL::X509::Certificate#version= calls X509_set_version, and that sets the version stored in the certificate.  However, the version stored in certificate is one less than the actual certificate version (https://www.openssl.org/docs/manmaster/man3/X509_set_version.html). There are no version 4 certificates, and when using recent LibreSSL, drb ssl tests all fail without this change.