### PR TITLE
Provide a 'Changelog' link on rubygems.org/gems/drb

### DIFF
--- a/drb.gemspec
+++ b/drb.gemspec
@@ -18,6 +18,7 @@ Gem::Specification.new do |spec|
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = spec.homepage
+  spec.metadata["changelog_uri"] = "https://github.com/ruby/drb/releases"
 
   spec.files         = %w[
     LICENSE.txt


### PR DESCRIPTION
By providing a 'changelog_uri' in the metadata of the gemspec a 'Changelog' link will be shown on https://rubygems.org/gems/drb which makes it quick and easy for someone to check on the changes introduced with a new version.

Details of this functionality can be found on https://guides.rubygems.org/specification-reference/