### PR TITLE
Avoid use of id2ref for weak mapping

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -51,6 +51,7 @@ require 'io/wait'
 require 'monitor'
 require_relative 'eq'
 require_relative 'version'
+require_relative 'weakidconv'
 
 #
 # == Overview
@@ -347,39 +348,6 @@ module DRb
   # Error raised when an error occurs on the underlying communication
   # protocol.
   class DRbConnError < DRbError; end
-
-  # Class responsible for converting between an object and its id.
-  #
-  # This, the default implementation, uses an object's local ObjectSpace
-  # __id__ as its id.  This means that an object's identification over
-  # drb remains valid only while that object instance remains alive
-  # within the server runtime.
-  #
-  # For alternative mechanisms, see DRb::TimerIdConv in drb/timeridconv.rb
-  # and DRbNameIdConv in sample/name.rb in the full drb distribution.
-  class DRbIdConv
-
-    # Convert an object reference id to an object.
-    #
-    # This implementation looks up the reference id in the local object
-    # space and returns the object it refers to.
-    def to_obj(ref)
-      ObjectSpace._id2ref(ref)
-    end
-
-    # Convert an object into a reference id.
-    #
-    # This implementation returns the object's __id__ in the local
-    # object space.
-    def to_id(obj)
-      case obj
-      when Object
-        obj.nil? ? nil : obj.__id__
-      when BasicObject
-        obj.__id__
-      end
-    end
-  end
 
   # Mixin module making an object undumpable or unmarshallable.
   #
@@ -1349,7 +1317,7 @@ module DRb
   # started by calling DRb.start_service.
   class DRbServer
     @@acl = nil
-    @@idconv = DRbIdConv.new
+    @@idconv = WeakIdConv.new
     @@secondary_server = nil
     @@argc_limit = 256
     @@load_limit = 0xffffffff
@@ -1940,4 +1908,4 @@ end
 # :stopdoc:
 DRbObject = DRb::DRbObject
 DRbUndumped = DRb::DRbUndumped
-DRbIdConv = DRb::DRbIdConv
+DRbIdConv = DRb::WeakIdConv

--- a/lib/drb/id2refconv.rb
+++ b/lib/drb/id2refconv.rb
@@ -1,0 +1,27 @@
+# Deprecated: Uses internal API ObjectSpace._id2ref and is replaced
+#             by WeakIdConv.
+module DRb
+  class DRbIdConv
+
+    # Convert an object reference id to an object.
+    #
+    # This implementation looks up the reference id in the local object
+    # space and returns the object it refers to.
+    def to_obj(ref)
+      ObjectSpace._id2ref(ref)
+    end
+
+    # Convert an object into a reference id.
+    #
+    # This implementation returns the object's __id__ in the local
+    # object space.
+    def to_id(obj)
+      case obj
+      when Object
+        obj.nil? ? nil : obj.__id__
+      when BasicObject
+        obj.__id__
+      end
+    end
+  end
+end

--- a/lib/drb/timeridconv.rb
+++ b/lib/drb/timeridconv.rb
@@ -12,7 +12,7 @@ module DRb
   #
   #  DRb.install_id_conv TimerIdConv.new 60 # one minute
 
-  class TimerIdConv < DRbIdConv
+  class TimerIdConv
     class TimerHolder2 # :nodoc:
       include MonitorMixin
 

--- a/lib/drb/weakidconv.rb
+++ b/lib/drb/weakidconv.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: false
-require_relative 'drb'
 require 'monitor'
 
 module DRb
 
-  # To use WeakIdConv:
-  #
-  #  DRb.start_service(nil, nil, {:idconv => DRb::WeakIdConv.new})
-
-  class WeakIdConv < DRbIdConv
+  class WeakIdConv
     class WeakSet
       include MonitorMixin
       def initialize


### PR DESCRIPTION
Revisiting my report in https://bugs.ruby-lang.org/issues/15711 and trying to finally get rid of the use of `ObjectSpace._id2ref` in drb. That report was closed but never actually fixed in DRb.

The implementation of `ObjectSpace._id2ref` on JRuby (and TruffleRuby) is very expensive, and on JRuby we normally do not have it enabled because it impacts performance of the entire runtime.

This alternate implementation uses the `weakref` library to build a weak ID map. It could possibly use the new ObjectSpace::WeakMap, but until recently that did not support Fixnum keys and I did not want to break DRb for older Ruby versions.

Unfortunately, due to the lack of "reference queue" support in Ruby's Weakref, this implementation must do a full scan for dead references. This may be possible to improve, and would probably be resolved by using WeakMap.

We recently got another report pry-remote not working on JRuby. pry-remote uses DRb, and DRb still uses `ObjectSpace._id2ref` to simulate a weak map of objects. We would like to get this fixed and released so users can use pry-remote without enabling full ObjectSpace support.

Notes:

* This is only enabled for JRuby in this patch. It could be enabled for all Rubies.
* When using this implementation on CRuby, all tests pass.
* No attempt is made to ensure the thread-safety of the weak Hash. A mutex could be introduced for this, or it may be ok if we switch to WeakMap.

Edit: Modified to use existing thread-safe `WeakMap`-based implementation `WeakIdConv` by default. Without it being default, users of DRb will always end up using the `_id2ref` version. We should simply eliminate that possibility.