### PR TITLE
[doc] Update links

### DIFF
--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -35,11 +35,11 @@
 # [http://www2a.biglobe.ne.jp/~seki/ruby/druby.en.html]
 #    The English version of the dRuby home page.
 #
-# [http://pragprog.com/book/sidruby/the-druby-book]
+# [https://web.archive.org/web/20160611151955/https://pragprog.com/book/sidruby/the-druby-book]
 #    The dRuby Book: Distributed and Parallel Computing with Ruby
 #    by Masatoshi Seki and Makoto Inoue
 #
-# [http://www.ruby-doc.org/docs/ProgrammingRuby/html/ospace.html]
+# [http://ruby-doc.com/docs/ProgrammingRuby/html/ospace.html]
 #   The chapter from *Programming* *Ruby* by Dave Thomas and Andy Hunt
 #   which discusses dRuby.
 #


### PR DESCRIPTION
The book is out of print, and its page removed. So, I used archive.org's linking to an old page.

I also updated the Programming Ruby book link, to point at the right page.