### PR TITLE
Remove dangling reference to the dRuby home page from the overview

### DIFF
--- a/README.md
+++ b/README.md
@@ -4,12 +4,6 @@ dRuby is a distributed object system for Ruby.  It allows an object in one
 Ruby process to invoke methods on an object in another Ruby process on the
 same or a different machine.
 
-The Ruby standard library contains the core classes of the dRuby package.
-However, the full package also includes access control lists and the
-Rinda tuple-space distributed task management system, as well as a
-large number of samples.  The full dRuby package can be downloaded from
-the dRuby home page (see *References*).
-
 For an introduction and examples of usage see the documentation to the
 DRb module.
 

--- a/lib/drb/drb.rb
+++ b/lib/drb/drb.rb
@@ -17,12 +17,6 @@
 # Ruby process to invoke methods on an object in another Ruby process on the
 # same or a different machine.
 #
-# The Ruby standard library contains the core classes of the dRuby package.
-# However, the full package also includes access control lists and the
-# Rinda tuple-space distributed task management system, as well as a
-# large number of samples.  The full dRuby package can be downloaded from
-# the dRuby home page (see *References*).
-#
 # For an introduction and examples of usage see the documentation to the
 # DRb module.
 #


### PR DESCRIPTION
The "(see References)" note pointed at a section that does not exist in the README

Fixes https://github.com/ruby/drb/issues/32