### PR TITLE
CI: Fix core_assertions LoadError in Windows cases

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -4,4 +4,4 @@ gemspec
 
 gem "rake"
 gem "test-unit"
-gem "test-unit-ruby-core", git: "https://github.com/ruby/test-unit-ruby-core"
+gem "test-unit-ruby-core"


### PR DESCRIPTION
I faced the following test failures in Windows cases in my fork repository. Let me test it in this repository.

https://github.com/junaruga/ruby-drb/actions/runs/32027865148/job/95381019434

```
Run bundle exec rake
D:/a/ruby-drb/ruby-drb/test/lib/helper.rb:2:in 'Kernel#require': cannot load such file -- core_assertions (LoadError)
	from D:/a/ruby-drb/ruby-drb/test/lib/helper.rb:2:in '<top (required)>'
	from <internal:D:/rubyinstaller-head-x64/lib/ruby/4.1.0+4/rubygems/core_ext/kernel_require.rb>:139:in 'Kernel#require'
rake aborted!
Command failed with status (1)
D:/a/ruby-drb/ruby-drb/vendor/bundle/ruby/4.1.0+4/gems/rake-13.4.2/exe/rake:27:in '<top (required)>'
D:/rubyinstaller-head-x64/bin/bundle:33:in '<main>'
Tasks: TOP => default => test
(See full trace by running task with --trace)
Error: Process completed with exit code 1.
```